### PR TITLE
Update infrastructure.yml to enable manual run

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -6,6 +6,7 @@ on:
       paths:
         - ".github/workflows/infrastructure.yml"
         - "infrastructure/**"
+    workflow_dispatch:    
 
 name: Deploy infrastructure
 jobs:


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/infrastructure.yml` file. The change adds the `workflow_dispatch` trigger to the workflow configuration.

* [`.github/workflows/infrastructure.yml`](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40R9): Added `workflow_dispatch` trigger to enable manual triggering of the workflow.