### PR TITLE
Update README.md to add instructions for creating a resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ After you test and verify the new revision, you can then point production traffi
 The code snippets demonstrate the process of setting up a Blue-Green deployment using Azure ContainerApps and GitHub Actions. Make sure to follow the instructions carefully and set the required secrets and environment variables in your GitHub repository. Once everything is set up, you can make changes to the sample app, create a pull request, and merge it to the main branch to trigger the deployment process.
 
 ## Create environment
+
 Create a resource group for the environment. The following will create a new resource group in the `swedencentral` region.
+
 ```bash
 az group create --name <name-of-resource-group> --location swedencentral
 ```


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds blank lines for better readability in the "Create environment" section. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29-R31): Added blank lines before and after the command to create a new resource group.