### PR TITLE
docs: update link to azuredevops repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ After you test and verify the new revision, you can then point production traffi
 The code snippets demonstrate the process of setting up a Blue-Green deployment using Azure ContainerApps and GitHub Actions. Make sure to follow the instructions carefully and set the required secrets and environment variables in your GitHub repository. Once everything is set up, you can make changes to the sample app, create a pull request, and merge it to the main branch to trigger the deployment process.
 
 ## AzureDevOps Repo
-The equivalent replica of this repo in AzureDevops can be found [here](https://dev.azure.com/kamimanzoor/azure-container-apps/_git/BlueGreen)
+The equivalent replica of this repo in AzureDevops can be found [here](https://dev.azure.com/kmanzoor/aca-demos/_git/BlueGreen)
 
 ## Fork the repository
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change updates the link to the AzureDevOps repository to reflect a new URL.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Updated the AzureDevOps repository link from `https://dev.azure.com/kamimanzoor/azure-container-apps/_git/BlueGreen` to `https://dev.azure.com/kmanzoor/aca-demos/_git/BlueGreen`.